### PR TITLE
Fix 404 when loading non-home page directly

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,6 @@
+/sponsors          /sponsors
+/about             /about
+/faq               /faq
+/speakers          /speakers
+/schedule          /schedule
+/                  /

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,1 @@
-/sponsors          /sponsors
-/about             /about
-/faq               /faq
-/speakers          /speakers
-/schedule          /schedule
-/                  /
+/*   /index.html   200


### PR DESCRIPTION
When going to pages like https://vandyhacks.org/about directly instead of clicking on the buttons, it gives a 404.